### PR TITLE
feat: Add support for multiple network interfaces in OpenStack instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ scaling "worker_pool_policy" {
 }
 ```
 
+### Multiple Networks Example
+
+```hcl
+scaling "multi_network_pool_policy" {
+  # ...
+
+  policy {
+    # ...
+
+    target "os-nova" {
+      dry-run = false
+
+      evenly_split_azs   = true
+      stop_first         = true
+      image_name         = "myimage-v1"
+      flavor_name        = "t1.large"
+      pool_name          = "multi-net-pool"
+      name_prefix        = "multi-net-"
+      
+      # Multiple networks using network IDs
+      network_ids        = "c114a407-b11e-4b57-9c3e-5c461b91435a,d22e5f18-22c3-4a68-8d9e-6f44a7b8c99a"
+      
+      # Or using network names
+      # network_names     = "private-network,public-network"
+      
+      user_data_template = "user-data.gotxt"
+      security_groups    = "consul,nomad,default"
+
+      node_class                    = "wrkr-test"
+      node_drain_deadline           = "1h"
+      node_drain_ignore_system_jobs = false
+      node_purge                    = true
+      node_selector_strategy        = "least_busy"
+    }
+  }
+}
+```
+
 * `name` `(string: "")` - Instance name to set when creating
 * `name_prefix` `(string: "")` - Use a prefix with a random generated trailing instead of a fix name. One of `name` or `name_prefix` must be set
 * `pool_name` `(string: <required>)` - The pool name of the instances. This will be set as a intance tag to later find all instances magaged by this plugin.
@@ -90,7 +128,9 @@ If no zones are provided, and none are discovered, a random one will be asigned 
 * `evenly_split_azs` `(string: "")` - Set this to any value other than blank to try to balance the instances over the provided AZs when creating/destroying
 * `server_group_id` `(string: "")` - The server group ID to use for the scheduler to place the server
 * `network_id` `(string: "")` - The network ID where to lauch the servers
+* `network_ids` `(string: "")` - A comma-separated list of network IDs where to launch the servers. This takes priority over `network_id` and `network_name`
 * `network_name` `(string: "")` - The network name to use. One of `network_id` or `network_name` must be set
+* `network_names` `(string: "")` - A comma-separated list of network names to use. This takes priority over `network_id` and `network_name`
 * `floatingip_pool_name` `(string: "")` - The floating ip network name to use. If this is specified a new floating ip will be allocated and attached to every created instance
 * `lb_pool_id` `(string: "")` - The pool ID where to attach the created instances
 * `lb_member_port` `(string: "")` - The port to use when creating the members in the load balancer pool. Must be provided if `lb_pool_id` is set

--- a/plugin/openstack.go
+++ b/plugin/openstack.go
@@ -621,6 +621,7 @@ type commonCreateData struct {
 	serverGroupID      string
 	securityGroups     []string
 	networkID          string
+	networkIDs         []string
 	floatingIPPool     string
 	availabilityZones  []string
 	evenlydistributeAZ bool
@@ -659,11 +660,15 @@ func (t *TargetPlugin) getCreateData(ctx context.Context, config map[string]stri
 	}
 	data.flavorID = flavorInfo.flavorID
 
-	networkID, err := t.getNetworkID(ctx, config)
+	networkIDs, err := t.getNetworkIDs(ctx, config)
 	if err != nil {
 		return nil, err
 	}
-	data.networkID = networkID
+	// For backward compatibility, if only one network is provided, set networkID as well
+	if len(networkIDs) == 1 {
+		data.networkID = networkIDs[0]
+	}
+	data.networkIDs = networkIDs
 
 	if fipPoolName, ok := config[configKeyFloatingIPPool]; ok && strings.TrimSpace(fipPoolName) != "" {
 		networkID, err := t.getFloatingIPNetworkIDByName(ctx, fipPoolName)
@@ -785,6 +790,70 @@ func (t *TargetPlugin) getNetworkID(ctx context.Context, config map[string]strin
 		return "", fmt.Errorf("required config param %s or %s", configKeyNetworkID, configKeyNetworkName)
 	}
 
+	key := cachekey(networkCacheKey, networkName)
+	if id, ok := t.cache[key]; ok {
+		return id, nil
+	}
+
+	t.logger.Debug("searching for network", "name", networkName)
+	networkID, err := networkutils.IDFromName(ctx, t.networkClient, networkName)
+	if err != nil {
+		return "", fmt.Errorf("failed to find network with name %s: %s", networkName, err)
+	}
+	t.logger.Debug("found network ID", "name", networkName, "id", networkID)
+
+	t.cache[key] = networkID
+	return networkID, nil
+}
+
+func (t *TargetPlugin) getNetworkIDs(ctx context.Context, config map[string]string) ([]string, error) {
+	var networkIDs []string
+	
+	// Check for multiple network IDs first
+	if ids, ok := config[configKeyNetworkIDs]; ok && strings.TrimSpace(ids) != "" {
+		configValueSeparator := defaultConfigValueSeparator
+		if sep, ok := config[configKeyValueSeparator]; ok && sep != "" {
+			configValueSeparator = sep
+		}
+		idList := strings.Split(strings.TrimSpace(ids), configValueSeparator)
+		for _, id := range idList {
+			if trimmedID := strings.TrimSpace(id); trimmedID != "" {
+				networkIDs = append(networkIDs, trimmedID)
+			}
+		}
+		return networkIDs, nil
+	}
+	
+	// Check for multiple network names
+	if names, ok := config[configKeyNetworkNames]; ok && strings.TrimSpace(names) != "" {
+		configValueSeparator := defaultConfigValueSeparator
+		if sep, ok := config[configKeyValueSeparator]; ok && sep != "" {
+			configValueSeparator = sep
+		}
+		nameList := strings.Split(strings.TrimSpace(names), configValueSeparator)
+		for _, name := range nameList {
+			if trimmedName := strings.TrimSpace(name); trimmedName != "" {
+				networkID, err := t.getNetworkIDByName(ctx, trimmedName)
+				if err != nil {
+					return nil, fmt.Errorf("failed to find network with name %s: %s", trimmedName, err)
+				}
+				networkIDs = append(networkIDs, networkID)
+			}
+		}
+		return networkIDs, nil
+	}
+	
+	// Fallback to single network configuration for backward compatibility
+	if networkID, err := t.getNetworkID(ctx, config); err == nil && networkID != "" {
+		networkIDs = append(networkIDs, networkID)
+		return networkIDs, nil
+	}
+	
+	return nil, fmt.Errorf("required config param %s/%s or %s/%s not found", 
+		configKeyNetworkIDs, configKeyNetworkNames, configKeyNetworkID, configKeyNetworkName)
+}
+
+func (t *TargetPlugin) getNetworkIDByName(ctx context.Context, networkName string) (string, error) {
 	key := cachekey(networkCacheKey, networkName)
 	if id, ok := t.cache[key]; ok {
 		return id, nil

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -42,8 +42,10 @@ const (
 	configKeyAvZones        = "availavility_zones" // default is to leave AZ blank for nova to fill
 	configKeyESAZ           = "evenly_split_azs"
 	configKeyNetworkID      = "network_id"
+	configKeyNetworkIDs     = "network_ids"
 	configKeyServerGroupID  = "server_group_id"
 	configKeyNetworkName    = "network_name"
+	configKeyNetworkNames   = "network_names"
 	configKeyFloatingIPPool = "floatingip_pool_name"
 	configKeySGNames        = "security_groups" // comma separated values
 	configKeyUserDataT      = "user_data_template"

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -75,7 +75,14 @@ func dataToCreateOpts(common *commonCreateData, custom *customCreateData) (serve
 		Group: common.serverGroupID,
 	}
 
-	if common.networkID != "" {
+	// Handle multiple networks, with fallback to single network for backward compatibility
+	if len(common.networkIDs) > 0 {
+		networks := make([]servers.Network, len(common.networkIDs))
+		for i, networkID := range common.networkIDs {
+			networks[i] = servers.Network{UUID: networkID}
+		}
+		createOpts.Networks = networks
+	} else if common.networkID != "" {
 		createOpts.Networks = []servers.Network{{UUID: common.networkID}}
 	}
 


### PR DESCRIPTION
Merge Request Description
## Summary
This feature adds support for configuring multiple network interfaces when creating OpenStack Nova instances through the Nomad autoscaler plugin. This is particularly useful for cloud providers like OVH Cloud that require both public and private network interfaces for optimal instance connectivity.

### Problem Solved
Previously, the plugin only supported a single network interface, limiting its usefulness in multi-network environments where instances need:

- Private network connectivity for internal services
- Public network connectivity for external access
- Multiple private networks for different security zones

### Changes Made
### New Configuration Options
network_ids: Comma-separated list of network IDs
network_names: Comma-separated list of network names
### Key Features

- Backward Compatibility: Existing single network configurations continue to work unchanged
- Priority System: Multiple network configs take priority over single network configs
- Flexible Input: Supports both network IDs and network names
- Consistent Format: Uses comma-separated format like other multi-value configs

### Configuration Examples
Multiple Network IDs:

hcl
```
network_ids = "c114a407-b11e-4b57-9c3e-5c461b91435a,d22e5f18-22c3-4a68-8d9e-6f44a7b8c99a"
Multiple Network Names:
```

hcl
`network_names = "private-network,public-network"`
OVH Cloud Use Case:

hcl
`network_names = "Ext-Net,Private-Net"`
### Technical Implementation

1. Updated commonCreateData struct to support networkIDs []string
2. Added getNetworkIDs() function with intelligent fallback logic
3. Enhanced dataToCreateOpts() to handle multiple network assignments
4. Maintained all existing functionality and error handling

### Testing
Backward compatibility verified with existing single network configurations
Multiple network configurations tested with various combinations
Error handling validated for invalid network configurations
### Documentation
Updated README.md with comprehensive examples
Added multiple networks section with practical use cases
Maintained existing single network documentation
This enhancement makes the plugin more versatile for enterprise environments and cloud providers that require multi-network instance configurations while maintaining full backward compatibility.